### PR TITLE
Remove unneeded use of the multiline flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var comment = module.exports = function () {
-	return new RegExp('(?:' + comment.line().source + ')|(?:' + comment.block().source + ')', 'gm');
+	return new RegExp('(?:' + comment.line().source + ')|(?:' + comment.block().source + ')', 'g');
 };
 
 comment.line = function () {


### PR DESCRIPTION
The regex doesn’t contain `^` or `$` so why bother setting the `m` flag?
